### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish-language-packs.yml
+++ b/.github/workflows/publish-language-packs.yml
@@ -18,14 +18,14 @@ jobs:
       # Mints a short-lived installation token scoped to the App's org repos.
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.MAHO_ORGANIZATION_CONTROLLER_CLIENT_ID }}
           private-key: ${{ secrets.MAHO_ORGANIZATION_CONTROLLER_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout monorepo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Git
         run: |

--- a/.github/workflows/upload-sources-to-crowdin.yml
+++ b/.github/workflows/upload-sources-to-crowdin.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout monorepo
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Uses the runner's preinstalled Node/npm (no setup-node action needed).
       # Pushes the latest en_US source strings to Crowdin, then queues MT


### PR DESCRIPTION
Pin all GitHub Actions to full commit SHAs (with version comments) via [pinact](https://github.com/suzuki-shunsuke/pinact), so a moved tag can't swap the action's code under us. Dependabot keeps the SHA and the comment up to date on future releases.